### PR TITLE
fix netlify CMS configuration

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -56,7 +56,7 @@ collections:
       - name: path
         label: Path
         widget: string
-        pattern: [/]
+        pattern: [/, "Path must start with /"]
         hint: "Path must start with /"
       - { name: date, label: Date, widget: datetime }
       - { name: title, label: Title }


### PR DESCRIPTION
There is an error when you try to access the CMS.
```
Error loading the CMS configuration
Config Errors:
'collections[1].fields[1].pattern' should NOT have fewer than 2 items
Check your config.yml file.
```
This error is because the pattern config is expecting two array items, the regex and error message.

**Steps to reproduce**
1. `gatsby new gatsby-starter-delog https://github.com/W3Layouts/gatsby-starter-delog`
2. `cd gatsby-starter-delog`
3. `gatsby develop`
4. Go to http://localhost:8000/admin/#/ 