### PR TITLE
Updated the file to match the new Netlify CMS standards and fixed the…

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -56,7 +56,7 @@ collections:
       - name: path
         label: Path
         widget: string
-        pattern: [/]
+        pattern: [".{8,}", "Must have at least 8 characters"]
         hint: "Path must start with /"
       - { name: date, label: Date, widget: datetime }
       - { name: title, label: Title }


### PR DESCRIPTION
… error collections[1].fields[1].pattern' should NOT have fewer than 2 items